### PR TITLE
Forbid extra fields on query method

### DIFF
--- a/vectorapi/routes/collection_points.py
+++ b/vectorapi/routes/collection_points.py
@@ -91,6 +91,8 @@ class QueryPointRequest(BaseModel):
     top_k: int = 10
     filter: Optional[Dict[str, Any]] = None
 
+    class Config:
+        extra = "forbid"
 
 @router.post(
     "/{collection_name}/query",
@@ -98,10 +100,17 @@ class QueryPointRequest(BaseModel):
 )
 async def query_points(
     collection_name: str,
-    request: QueryPointRequest,
+    request: dict,
     client: StoreClient,
 ):
     """Query collection with a given embedding query."""
+    try:
+        request = QueryPointRequest(**request)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Extra inputs are not permitted: {e}",
+        )
     collection = await get_collection(collection_name, client)
 
     logger.debug(f"Searching {request.top_k} embeddings for query")


### PR DESCRIPTION
Added pydantic config to forbid extra types on query (to be added in every struct if we follow the approach)

Though by default pydantic will raise a ValueError
```
{
    "detail": [
        {
            "type": "extra_forbidden",
            "loc": [
                "body",
                "filters"
            ],
            "msg": "Extra inputs are not permitted",
            "input": {
                "metadata_filter": {
                    "$eq": "filter2"
                }
            },
            "url": "https://errors.pydantic.dev/2.3/v/extra_forbidden"
        }
    ]
}
```
which is not captured from the method itself as it's at the argument level. 

We can accept the raw dictionary and run the validation separately. 
